### PR TITLE
Add manufacturer and model dropdowns to new item dialog

### DIFF
--- a/inventar/data/json_repo.py
+++ b/inventar/data/json_repo.py
@@ -73,3 +73,9 @@ class JSONRepository(AbstractRepository):
 
         def distinct_object_types(self) -> List[str]:
                 return sorted({item.objekttyp for item in self.items if item.objekttyp})
+
+        def distinct_manufacturers(self) -> List[str]:
+                return sorted({item.hersteller for item in self.items if item.hersteller})
+
+        def distinct_models(self) -> List[str]:
+                return sorted({item.modell for item in self.items if item.modell})

--- a/inventar/data/repository.py
+++ b/inventar/data/repository.py
@@ -45,6 +45,14 @@ class AbstractRepository(abc.ABC):
         def distinct_object_types(self) -> List[str]:
                 """Liefert distinct Objekttypen für die ComboBox."""
 
+        @abc.abstractmethod
+        def distinct_manufacturers(self) -> List[str]:
+                """Liefert distinct Hersteller für die ComboBox."""
+
+        @abc.abstractmethod
+        def distinct_models(self) -> List[str]:
+                """Liefert distinct Modelle für die ComboBox."""
+
 
 class RepositoryFactory:
         """Factory zur Auswahl des passenden Backends."""

--- a/inventar/data/sqlite_repo.py
+++ b/inventar/data/sqlite_repo.py
@@ -200,3 +200,17 @@ class SQLiteRepository(AbstractRepository):
                         "SELECT DISTINCT objekttyp FROM items WHERE objekttyp <> '' ORDER BY objekttyp COLLATE NOCASE"
                 ).fetchall()
                 return [row[0] for row in rows if row[0]]
+
+        def distinct_manufacturers(self) -> List[str]:
+                conn = self._ensure_conn()
+                rows = conn.execute(
+                        "SELECT DISTINCT hersteller FROM items WHERE hersteller <> '' ORDER BY hersteller COLLATE NOCASE"
+                ).fetchall()
+                return [row[0] for row in rows if row[0]]
+
+        def distinct_models(self) -> List[str]:
+                conn = self._ensure_conn()
+                rows = conn.execute(
+                        "SELECT DISTINCT modell FROM items WHERE modell <> '' ORDER BY modell COLLATE NOCASE"
+                ).fetchall()
+                return [row[0] for row in rows if row[0]]

--- a/inventar/ui/item_dialog.py
+++ b/inventar/ui/item_dialog.py
@@ -30,12 +30,16 @@ class ItemDialog(QDialog):
                 item: Optional[Item] = None,
                 owners: Optional[list[str]] = None,
                 object_types: Optional[list[str]] = None,
+                manufacturers: Optional[list[str]] = None,
+                models: Optional[list[str]] = None,
         ) -> None:
                 super().__init__(parent)
                 self.setWindowTitle('Neues Objekt einfügen' if item is None else 'Objekt bearbeiten')
                 self.item = item
                 self.owners = owners or []
                 self.object_types = object_types or []
+                self.manufacturers = manufacturers or []
+                self.models = models or []
                 self._build_ui()
                 if item:
                         self._populate(item)
@@ -48,8 +52,14 @@ class ItemDialog(QDialog):
                 self.objekttyp_combo.setEditable(True)
                 if self.object_types:
                         self.objekttyp_combo.addItems(self.object_types)
-                self.hersteller_edit = QLineEdit()
-                self.modell_edit = QLineEdit()
+                self.hersteller_combo = QComboBox()
+                self.hersteller_combo.setEditable(True)
+                if self.manufacturers:
+                        self.hersteller_combo.addItems(sorted(self.manufacturers))
+                self.modell_combo = QComboBox()
+                self.modell_combo.setEditable(True)
+                if self.models:
+                        self.modell_combo.addItems(sorted(self.models))
 
                 self.seriennummer_edit = QLineEdit()
                 self.einkaufsdatum_edit = QDateEdit()
@@ -68,9 +78,9 @@ class ItemDialog(QDialog):
                 form_layout.addWidget(QLabel('Objekttyp'), 0, 0)
                 form_layout.addWidget(self.objekttyp_combo, 0, 1)
                 form_layout.addWidget(QLabel('Hersteller'), 1, 0)
-                form_layout.addWidget(self.hersteller_edit, 1, 1)
+                form_layout.addWidget(self.hersteller_combo, 1, 1)
                 form_layout.addWidget(QLabel('Modell'), 2, 0)
-                form_layout.addWidget(self.modell_edit, 2, 1)
+                form_layout.addWidget(self.modell_combo, 2, 1)
 
                 form_layout.addWidget(QLabel('Seriennummer'), 0, 2)
                 form_layout.addWidget(self.seriennummer_edit, 0, 3)
@@ -102,8 +112,22 @@ class ItemDialog(QDialog):
                                 self.objekttyp_combo.setCurrentIndex(index)
                         else:
                                 self.objekttyp_combo.setEditText(item.objekttyp)
-                self.hersteller_edit.setText(item.hersteller)
-                self.modell_edit.setText(item.modell)
+                if item.hersteller:
+                        index = self.hersteller_combo.findText(item.hersteller)
+                        if index >= 0:
+                                self.hersteller_combo.setCurrentIndex(index)
+                        else:
+                                self.hersteller_combo.setEditText(item.hersteller)
+                else:
+                        self.hersteller_combo.setCurrentText('')
+                if item.modell:
+                        index = self.modell_combo.findText(item.modell)
+                        if index >= 0:
+                                self.modell_combo.setCurrentIndex(index)
+                        else:
+                                self.modell_combo.setEditText(item.modell)
+                else:
+                        self.modell_combo.setCurrentText('')
                 self.seriennummer_edit.setText(item.seriennummer)
                 if item.einkaufsdatum:
                         qdate = QDate.fromString(item.einkaufsdatum, 'yyyy-MM-dd')
@@ -136,8 +160,8 @@ class ItemDialog(QDialog):
 
                 return {
                         'objekttyp': self.objekttyp_combo.currentText().strip(),
-                        'hersteller': self.hersteller_edit.text().strip(),
-                        'modell': self.modell_edit.text().strip(),
+                        'hersteller': self.hersteller_combo.currentText().strip(),
+                        'modell': self.modell_combo.currentText().strip(),
                         'seriennummer': self.seriennummer_edit.text().strip(),
                         'einkaufsdatum': _date_value(self.einkaufsdatum_edit),
                         'zuweisungsdatum': _date_value(self.zuweisungsdatum_edit),

--- a/inventar/ui/main_window.py
+++ b/inventar/ui/main_window.py
@@ -470,6 +470,8 @@ class MainWindow(QMainWindow):
                         self,
                         owners=self.repository.distinct_owners(),
                         object_types=self.object_types,
+                        manufacturers=self.repository.distinct_manufacturers(),
+                        models=self.repository.distinct_models(),
                 )
                 if dialog.exec() == ItemDialog.Accepted:
                         item = self._collect_dialog_data(dialog)
@@ -492,6 +494,8 @@ class MainWindow(QMainWindow):
                         item=selected,
                         owners=self.repository.distinct_owners(),
                         object_types=self.object_types,
+                        manufacturers=self.repository.distinct_manufacturers(),
+                        models=self.repository.distinct_models(),
                 )
                 if dialog.exec() != ItemDialog.Accepted:
                         return


### PR DESCRIPTION
## Summary
- add editable dropdowns for manufacturer and model in the item dialog to reuse existing values
- extend the repository interface and backends to provide distinct manufacturers and models
- pass the new value lists when opening the item dialog for create and edit actions

## Testing
- python -m compileall inventar

------
https://chatgpt.com/codex/tasks/task_e_68da98bd7590832e9bfff0a8aba3c79c