### PR TITLE
Add item deactivation workflow and shrink input fields

### DIFF
--- a/inventar/data/models.py
+++ b/inventar/data/models.py
@@ -18,6 +18,7 @@ class Item:
         zuweisungsdatum: str = field(default='')
         aktueller_besitzer: str = field(default='')
         anmerkungen: str = field(default='')
+        stillgelegt: bool = field(default=False)
 
         def to_dict(self) -> dict:
                 """Konvertiert das Item in ein Dictionary."""
@@ -32,6 +33,7 @@ class Item:
                         'zuweisungsdatum': self.zuweisungsdatum,
                         'aktueller_besitzer': self.aktueller_besitzer,
                         'anmerkungen': self.anmerkungen,
+                        'stillgelegt': self.stillgelegt,
                 }
 
         @classmethod
@@ -49,6 +51,7 @@ class Item:
                                 zuweisungsdatum=row.get('zuweisungsdatum', ''),
                                 aktueller_besitzer=row.get('aktueller_besitzer', ''),
                                 anmerkungen=row.get('anmerkungen', ''),
+                                stillgelegt=bool(row.get('stillgelegt', 0)),
                         )
                 return cls(
                         id=row[0],
@@ -60,6 +63,7 @@ class Item:
                         zuweisungsdatum=row[6],
                         aktueller_besitzer=row[7],
                         anmerkungen=row[8],
+                        stillgelegt=bool(row[9]) if len(row) > 9 else False,
                 )
 
         def copy(self, **updates: object) -> Item:

--- a/inventar/data/repository.py
+++ b/inventar/data/repository.py
@@ -38,6 +38,10 @@ class AbstractRepository(abc.ABC):
                 """Löscht ein Item."""
 
         @abc.abstractmethod
+        def deactivate(self, item_id: int) -> Item:
+                """Markiert ein Item als stillgelegt."""
+
+        @abc.abstractmethod
         def distinct_owners(self) -> List[str]:
                 """Liefert distinct Besitzer für die ComboBox."""
 

--- a/inventar/ui/item_dialog.py
+++ b/inventar/ui/item_dialog.py
@@ -79,6 +79,23 @@ class ItemDialog(QDialog):
                 self.aktueller_besitzer_combo.addItems(sorted(self.owners))
                 self.anmerkungen_edit = QPlainTextEdit()
 
+                def _shrink_widget(widget: QWidget, minimum: int = 16) -> None:
+                        hint = widget.sizeHint()
+                        if hint.isValid():
+                                widget.setFixedHeight(max(minimum, int(hint.height() * 0.5)))
+
+                for field in [
+                        self.objekttyp_combo,
+                        self.hersteller_combo,
+                        self.modell_combo,
+                        self.seriennummer_edit,
+                        self.einkaufsdatum_edit,
+                        self.zuweisungsdatum_edit,
+                        self.aktueller_besitzer_combo,
+                ]:
+                        _shrink_widget(field)
+                _shrink_widget(self.anmerkungen_edit, minimum=40)
+
                 form_layout.addWidget(QLabel('Objekttyp'), 0, 0)
                 form_layout.addWidget(self.objekttyp_combo, 0, 1)
                 form_layout.addWidget(QLabel('Hersteller'), 1, 0)


### PR DESCRIPTION
## Summary
- add a deactivation flag to inventory items across repositories and hide retired entries from lists and filters
- implement a Stilllegen button that marks the selected record as retired with immediate visual feedback
- shrink the item dialog input widgets so dropdowns and text fields use 50% of their previous height

## Testing
- python -m compileall inventar

------
https://chatgpt.com/codex/tasks/task_e_68dbab214d60832e8e77dde8b74f7b5d