### PR TITLE
Implement global search and deactivation dataset tools

### DIFF
--- a/inventar/data/models.py
+++ b/inventar/data/models.py
@@ -73,6 +73,25 @@ class Item:
                 data.update(updates)
                 return Item(**data)
 
+        def with_stillgelegt_note(self) -> Item:
+                """Stellt sicher, dass stillgelegte Einträge eine Notiz tragen."""
+
+                if not self.stillgelegt:
+                        return self
+
+                note = self.anmerkungen or ""
+                if "stillgelegt" in note.lower():
+                        # Gleiche Zeichenkette zurückgeben, um unnötige Kopien zu vermeiden.
+                        return self if note == self.anmerkungen else self.copy(anmerkungen=note)
+
+                note_stripped = note.strip()
+                if note_stripped:
+                        separator = "\n" if not note.endswith("\n") else ""
+                        updated_note = f"{note}{separator}Stillgelegt"
+                else:
+                        updated_note = "Stillgelegt"
+                return self.copy(anmerkungen=updated_note)
+
 
 def iso_date_or_today(value: str | None) -> str:
         """Hilfsfunktion um sicher ISO-Daten zu liefern."""

--- a/inventar/data/repository.py
+++ b/inventar/data/repository.py
@@ -46,6 +46,14 @@ class AbstractRepository(abc.ABC):
                 """Liefert distinct Besitzer für die ComboBox."""
 
         @abc.abstractmethod
+        def clear_owner(self, owner: str) -> int:
+                """Entfernt einen Besitzer aus allen Einträgen und liefert die Anzahl der Aktualisierungen."""
+
+        @abc.abstractmethod
+        def clear_serial_number(self, serial_number: str) -> int:
+                """Entfernt eine Seriennummer aus allen Einträgen und liefert die Anzahl der Aktualisierungen."""
+
+        @abc.abstractmethod
         def distinct_object_types(self) -> List[str]:
                 """Liefert distinct Objekttypen für die ComboBox."""
 


### PR DESCRIPTION
## Summary
- add automatic "Stillgelegt" annotations and persist them across repositories
- convert the search bar to a global multi-field search and adjust button layout
- provide controls to remove owner or serial number values and relocate the reset button next to zoom controls

## Testing
- python -m compileall inventar

------
https://chatgpt.com/codex/tasks/task_e_68dbbe606abc832e8536b9901ef615d7