### PR TITLE
Persist custom filter entries for reuse in new object dialog

### DIFF
--- a/inventar/data/repository.py
+++ b/inventar/data/repository.py
@@ -81,6 +81,18 @@ class AbstractRepository(abc.ABC):
         def distinct_serial_numbers(self) -> List[str]:
                 """Liefert distinct Seriennummern für die ComboBox."""
 
+        @abc.abstractmethod
+        def list_custom_values(self, category: str) -> List[str]:
+                """Liefert gespeicherte Zusatzwerte für Auswahlfelder."""
+
+        @abc.abstractmethod
+        def add_custom_value(self, category: str, value: str) -> None:
+                """Speichert einen neuen Zusatzwert für Auswahlfelder."""
+
+        @abc.abstractmethod
+        def remove_custom_value(self, category: str, value: str) -> None:
+                """Entfernt einen gespeicherten Zusatzwert."""
+
 
 class RepositoryFactory:
         """Factory zur Auswahl des passenden Backends."""


### PR DESCRIPTION
## Summary
- add repository APIs and persistence for custom selection values in both SQLite and JSON backends
- update main window filter actions to store and remove custom entries so they appear in the "Neues Objekt" dialog

## Testing
- python -m compileall inventar

------
https://chatgpt.com/codex/tasks/task_e_68dbfba1953c832e8b352d8d111e0e0c