### PR TITLE
Adjust table columns to stretch with window size

### DIFF
--- a/inventar/ui/main_window.py
+++ b/inventar/ui/main_window.py
@@ -281,7 +281,7 @@ class MainWindow(QMainWindow):
                 self.table.setSelectionMode(QAbstractItemView.SingleSelection)
                 self.table.doubleClicked.connect(self.edit_selected_item)
                 self.table.setSortingEnabled(True)
-                self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Interactive)
+                self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
                 self.table.setAlternatingRowColors(True)
 
                 self.printer = TablePrinter(self)


### PR DESCRIPTION
## Summary
- update the main window table header to stretch columns with the window size so the dataset view adapts automatically

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd2e19cf34832e94c5165b3136fed1