### PR TITLE
Ensure inventory table resizes with main window

### DIFF
--- a/inventar/ui/main_window.py
+++ b/inventar/ui/main_window.py
@@ -283,6 +283,7 @@ class MainWindow(QMainWindow):
                 self.table.setSortingEnabled(True)
                 self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
                 self.table.setAlternatingRowColors(True)
+                self.table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
 
                 self.printer = TablePrinter(self)
 
@@ -330,7 +331,7 @@ class MainWindow(QMainWindow):
                 self.delete_button.hide()
 
                 layout.addLayout(actions_layout)
-                layout.addWidget(self.table)
+                layout.addWidget(self.table, stretch=1)
 
                 zoom_layout = QHBoxLayout()
                 self.zoom_in_button = QToolButton()


### PR DESCRIPTION
## Summary
- allow the main table view to use an expanding size policy so it can grow with the window
- assign layout stretch to the table so it consumes the available vertical space

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd2ee2a86c832e9f4ea82806ea51d6