### PR TITLE
Move deactivation into item dialog

### DIFF
--- a/inventar/ui/item_dialog.py
+++ b/inventar/ui/item_dialog.py
@@ -13,6 +13,7 @@ from PySide6.QtWidgets import (
         QLabel,
         QLineEdit,
         QPlainTextEdit,
+        QSizePolicy,
         QVBoxLayout,
         QWidget,
 )
@@ -27,6 +28,7 @@ class ItemDialog(QDialog):
         ACTION_SAVE = 'save'
         ACTION_CANCEL = 'cancel'
         ACTION_DELETE = 'delete'
+        ACTION_DEACTIVATE = 'deactivate'
 
         def __init__(
                 self,
@@ -70,6 +72,9 @@ class ItemDialog(QDialog):
                 if self.models:
                         self.modell_combo.addItems(sorted(self.models))
 
+                for combo in (self.objekttyp_combo, self.hersteller_combo, self.modell_combo):
+                        combo.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+
                 self.seriennummer_edit = QLineEdit()
                 self.einkaufsdatum_edit = QDateEdit()
                 # Qt erwartet sein eigenes Datumsformat (dd.MM.yyyy) für die Anzeige.
@@ -82,7 +87,9 @@ class ItemDialog(QDialog):
                 self.aktueller_besitzer_combo = QComboBox()
                 self.aktueller_besitzer_combo.setEditable(True)
                 self.aktueller_besitzer_combo.addItems(sorted(self.owners))
+                self.aktueller_besitzer_combo.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
                 self.anmerkungen_edit = QPlainTextEdit()
+                self.anmerkungen_edit.setStyleSheet('background-color: white;')
 
                 form_layout.addWidget(QLabel('Objekttyp'), 0, 0)
                 form_layout.addWidget(self.objekttyp_combo, 0, 1)
@@ -115,8 +122,11 @@ class ItemDialog(QDialog):
                 self.button_box.rejected.connect(self._handle_cancel_clicked)
                 if self.item is not None:
                         edit_button = self.button_box.addButton('Bearbeiten', QDialogButtonBox.ActionRole)
+                        deactivate_button = self.button_box.addButton('Stilllegen', QDialogButtonBox.DestructiveRole)
+                        deactivate_button.setStyleSheet('background-color: #c62828; color: white;')
                         delete_button = self.button_box.addButton('Löschen', QDialogButtonBox.DestructiveRole)
                         edit_button.clicked.connect(self._handle_edit_clicked)
+                        deactivate_button.clicked.connect(self._handle_deactivate_clicked)
                         delete_button.clicked.connect(self._handle_delete_clicked)
                 layout.addWidget(self.button_box)
 
@@ -216,6 +226,10 @@ class ItemDialog(QDialog):
 
         def _handle_delete_clicked(self) -> None:
                 self._result_action = ItemDialog.ACTION_DELETE
+                self.done(QDialog.Accepted)
+
+        def _handle_deactivate_clicked(self) -> None:
+                self._result_action = ItemDialog.ACTION_DEACTIVATE
                 self.done(QDialog.Accepted)
 
         def _handle_cancel_clicked(self) -> None:

--- a/inventar/ui/main_window.py
+++ b/inventar/ui/main_window.py
@@ -323,7 +323,6 @@ class MainWindow(QMainWindow):
 
                 actions_layout = QHBoxLayout()
                 self.new_button = QPushButton('Neues Objekt')
-                self.deactivate_button = QPushButton('Stilllegen')
                 self.reset_button = QPushButton('Reset')
                 self.export_excel_button = QPushButton('Excel')
                 self.export_csv_button = QPushButton('CSV')
@@ -333,7 +332,7 @@ class MainWindow(QMainWindow):
                 self.print_button.setToolTip('Drucken (Ctrl+P)')
 
                 actions_layout.addWidget(self.new_button)
-                actions_layout.addWidget(self.deactivate_button)
+                actions_layout.addStretch()
 
                 layout.addLayout(actions_layout)
 
@@ -553,7 +552,6 @@ class MainWindow(QMainWindow):
 
         def _connect_signals(self) -> None:
                 self.new_button.clicked.connect(self.create_item)
-                self.deactivate_button.clicked.connect(self.deactivate_selected_item)
                 self.reset_button.clicked.connect(self.reset_filters)
                 self.export_excel_button.clicked.connect(partial(self.export_data, 'xlsx'))
                 self.export_csv_button.clicked.connect(partial(self.export_data, 'csv'))
@@ -862,6 +860,9 @@ class MainWindow(QMainWindow):
                 if dialog.result_action == ItemDialog.ACTION_DELETE:
                         self._delete_item(item)
                         return
+                if dialog.result_action == ItemDialog.ACTION_DEACTIVATE:
+                        self._deactivate_item(item)
+                        return
                 if result and dialog.result_action == ItemDialog.ACTION_SAVE:
                         updated = dialog.get_item()
                         try:
@@ -889,15 +890,11 @@ class MainWindow(QMainWindow):
                 self._load_items()
                 self.apply_filters()
 
-        def deactivate_selected_item(self) -> None:
-                item = self._selected_item()
-                if not item:
-                        return
+        def _deactivate_item(self, item: Item) -> None:
                 try:
                         if hasattr(self.repository, 'deactivate'):
                                 self.repository.deactivate(item)
                         else:
-                                # Fallback: markiere Flag und speichere
                                 setattr(item, 'stillgelegt', True)
                                 self.repository.update(item)
                 except RepositoryError as e:
@@ -905,6 +902,12 @@ class MainWindow(QMainWindow):
                         return
                 self._load_items()
                 self.apply_filters()
+
+        def deactivate_selected_item(self) -> None:
+                item = self._selected_item()
+                if not item:
+                        return
+                self._deactivate_item(item)
 
         # ---------- Export / Drucken ----------
         def _pick_export_path(self, suffix: str, filter_str: str) -> Optional[Path]:


### PR DESCRIPTION
## Summary
- remove the Stilllegen control from the main window and handle deactivation through the edit dialog
- add a red Stilllegen action to the object dialog and make the combo boxes responsive with a white notes field

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd36eb92b8832eade1e8416d707e26