### PR TITLE
Toggle stilllegen button in item dialog

### DIFF
--- a/inventar/ui/main_window.py
+++ b/inventar/ui/main_window.py
@@ -863,9 +863,6 @@ class MainWindow(QMainWindow):
                 if dialog.result_action == ItemDialog.ACTION_DELETE:
                         self._delete_item(item)
                         return
-                if dialog.result_action == ItemDialog.ACTION_DEACTIVATE:
-                        self._deactivate_item(item)
-                        return
                 if result and dialog.result_action == ItemDialog.ACTION_SAVE:
                         updated = dialog.get_item()
                         item_id = item.id or updated.id


### PR DESCRIPTION
## Summary
- remove the extra "Bearbeiten" action button from the item dialog when editing
- convert the "Stilllegen" control into a toggle that reflects and updates the stillgelegt state
- rely on the dialog save path to persist the new stillgelegt value when editing an item

## Testing
- python -m compileall inventar

------
https://chatgpt.com/codex/tasks/task_e_68dd40fcfc50832e9ce53e5c381d6c36